### PR TITLE
Qt5: Use XDG_DATA_DIR for themeHint::IconThemeSearchPaths

### DIFF
--- a/src/lxqtplatformtheme.h
+++ b/src/lxqtplatformtheme.h
@@ -91,6 +91,8 @@ private:
     QVariant cursorFlashTime_;
     QFileSystemWatcher *settingsWatcher_;
     QString settingsFile_;
+
+    QStringList xdgIconThemePaths() const;
 };
 
 #endif // LXQTPLATFORMTHEME_H


### PR DESCRIPTION
Copied from:
    qtbase/src/platformsupport/themes/genericunix/qgenericunixthemes.cpp

and made it an const member.
