### PR TITLE
Don't use automatic string conversions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,16 @@ qt5_add_dbus_adaptor(qtlxqt_SRCS
 
 add_library(qtlxqt MODULE ${qtlxqt_HDRS} ${qtlxqt_SRCS})
 
+target_compile_definitions(qtlxqt
+    PRIVATE
+        "QT_NO_FOREACH"
+        "QT_USE_QSTRINGBUILDER"
+        "QT_NO_CAST_FROM_ASCII"
+        "QT_NO_CAST_TO_ASCII"
+        "QT_NO_URL_CAST_FROM_STRING"
+        "QT_NO_CAST_FROM_BYTEARRAY"
+)
+
 target_link_libraries(qtlxqt
     Qt5::Widgets
     Qt5::DBus

--- a/src/lxqtplatformtheme.cpp
+++ b/src/lxqtplatformtheme.cpp
@@ -93,15 +93,15 @@ void LXQtPlatformTheme::loadSettings() {
     // as a fallback if a key is missing from the user config file ~/.config/lxqt/lxqt.conf.
     // So we can customize the default values in /etc/xdg/lxqt/lxqt.conf and does
     // not necessarily to hard code the default values here.
-    QSettings settings(QSettings::UserScope, "lxqt", "lxqt");
+    QSettings settings(QSettings::UserScope, QLatin1String("lxqt"), QLatin1String("lxqt"));
     settingsFile_ = settings.fileName();
 
     // icon theme
-    iconTheme_ = settings.value("icon_theme", "oxygen").toString();
-    iconFollowColorScheme_ = settings.value("icon_follow_color_scheme", iconFollowColorScheme_).toBool();
+    iconTheme_ = settings.value(QLatin1String("icon_theme"), QLatin1String("oxygen")).toString();
+    iconFollowColorScheme_ = settings.value(QLatin1String("icon_follow_color_scheme"), iconFollowColorScheme_).toBool();
 
     // read other widget related settings form LxQt settings.
-    QByteArray tb_style = settings.value("tool_button_style").toByteArray();
+    QByteArray tb_style = settings.value(QLatin1String("tool_button_style")).toByteArray();
     // convert toolbar style name to value
     QMetaEnum me = QToolBar::staticMetaObject.property(QToolBar::staticMetaObject.indexOfProperty("toolButtonStyle")).enumerator();
     int value = me.keyToValue(tb_style.constData());
@@ -111,7 +111,7 @@ void LXQtPlatformTheme::loadSettings() {
         toolButtonStyle_ = static_cast<Qt::ToolButtonStyle>(value);
 
     // single click activation
-    singleClickActivate_ = settings.value("single_click_activate").toBool();
+    singleClickActivate_ = settings.value(QLatin1String("single_click_activate")).toBool();
 
     // load Qt settings
     settings.beginGroup(QLatin1String("Qt"));
@@ -232,14 +232,14 @@ QPlatformDialogHelper *LXQtPlatformTheme::createPlatformDialogHelper(DialogType 
 
         // When a process has this environment set, that means glib event loop integration is disabled.
         // In this case, libfm-qt just won't work. So let's disable the file dialog helper and return nullptr.
-        if(qgetenv("QT_NO_GLIB") == "1") {
+        if(QString::fromLocal8Bit(qgetenv("QT_NO_GLIB")) == QLatin1String("1")) {
             return nullptr;
         }
 
         // The createFileDialogHelper() method is dynamically loaded from libfm-qt on demand
         if(createFileDialogHelper == nullptr) {
             // try to dynamically load libfm-qt.so
-            QLibrary libfmQtLibrary{"libfm-qt"};
+            QLibrary libfmQtLibrary{QLatin1String("libfm-qt")};
             libfmQtLibrary.load();
             if(!libfmQtLibrary.isLoaded()) {
                 return nullptr;
@@ -307,7 +307,7 @@ QVariant LXQtPlatformTheme::themeHint(ThemeHint hint) const {
     case SystemIconThemeName:
         return iconTheme_;
     case SystemIconFallbackThemeName:
-        return "hicolor";
+        return QLatin1String("hicolor");
     case IconThemeSearchPaths:
         return xdgIconThemePaths();
     case StyleNames:

--- a/src/lxqtsystemtrayicon.cpp
+++ b/src/lxqtsystemtrayicon.cpp
@@ -290,7 +290,7 @@ void LXQtSystemTrayIcon::init()
         QPlatformMenuItem *menuItem = menu->createMenuItem();
         menuItem->setParent(menu);
         menuItem->setText(tr("Quit"));
-        menuItem->setIcon(QIcon::fromTheme("application-exit"));
+        menuItem->setIcon(QIcon::fromTheme(QLatin1String("application-exit")));
         connect(menuItem, &QPlatformMenuItem::activated, qApp, &QApplication::quit);
         menu->insertMenuItem(menuItem, nullptr);
         updateMenu(menu);
@@ -369,9 +369,9 @@ void LXQtSystemTrayIcon::showMessage(const QString &title, const QString &msg,
 
 bool LXQtSystemTrayIcon::isSystemTrayAvailable() const
 {
-    QDBusInterface systrayHost("org.kde.StatusNotifierWatcher",
-                               "/StatusNotifierWatcher",
-                               "org.kde.StatusNotifierWatcher");
+    QDBusInterface systrayHost(QLatin1String("org.kde.StatusNotifierWatcher"),
+                               QLatin1String("/StatusNotifierWatcher"),
+                               QLatin1String("org.kde.StatusNotifierWatcher"));
 
     return systrayHost.isValid() && systrayHost.property("IsStatusNotifierHostRegistered").toBool();
 }

--- a/src/statusnotifieritem/statusnotifieritem.cpp
+++ b/src/statusnotifieritem/statusnotifieritem.cpp
@@ -36,12 +36,12 @@ int StatusNotifierItem::mServiceCounter = 0;
 StatusNotifierItem::StatusNotifierItem(QString id, QObject *parent)
     : QObject(parent),
     mAdaptor(new StatusNotifierItemAdaptor(this)),
-    mService(QString("org.freedesktop.StatusNotifierItem-%1-%2")
+    mService(QString::fromLatin1("org.freedesktop.StatusNotifierItem-%1-%2")
              .arg(QCoreApplication::applicationPid())
              .arg(++mServiceCounter)),
     mId(id),
-    mTitle("Test"),
-    mStatus("Active"),
+    mTitle(QLatin1String("Test")),
+    mStatus(QLatin1String("Active")),
     mMenu(nullptr),
     mMenuExporter(nullptr),
     mSessionBus(QDBusConnection::connectToBus(QDBusConnection::SessionBus, mService))
@@ -58,7 +58,7 @@ StatusNotifierItem::StatusNotifierItem(QString id, QObject *parent)
     registerToHost();
 
     // monitor the watcher service in case the host restarts
-    QDBusServiceWatcher *watcher = new QDBusServiceWatcher("org.kde.StatusNotifierWatcher",
+    QDBusServiceWatcher *watcher = new QDBusServiceWatcher(QLatin1String("org.kde.StatusNotifierWatcher"),
                                                            mSessionBus,
                                                            QDBusServiceWatcher::WatchForOwnerChange,
                                                            this);
@@ -75,11 +75,11 @@ StatusNotifierItem::~StatusNotifierItem()
 
 void StatusNotifierItem::registerToHost()
 {
-    QDBusInterface interface("org.kde.StatusNotifierWatcher",
-                             "/StatusNotifierWatcher",
-                             "org.kde.StatusNotifierWatcher",
+    QDBusInterface interface(QLatin1String("org.kde.StatusNotifierWatcher"),
+                             QLatin1String("/StatusNotifierWatcher"),
+                             QLatin1String("org.kde.StatusNotifierWatcher"),
                              mSessionBus);
-    interface.asyncCall("RegisterStatusNotifierItem", mService);
+    interface.asyncCall(QLatin1String("RegisterStatusNotifierItem"), mService);
 }
 
 void StatusNotifierItem::onServiceOwnerChanged(const QString& service, const QString& oldOwner,
@@ -230,7 +230,7 @@ void StatusNotifierItem::setContextMenu(QMenu* menu)
     }
     mMenu = menu;
 
-    setMenuPath("/MenuBar");
+    setMenuPath(QLatin1String("/MenuBar"));
     //Note: we need to destroy menu exporter before creating new one -> to free the DBus object path for new menu
     delete mMenuExporter;
     if (nullptr != mMenu)
@@ -242,16 +242,16 @@ void StatusNotifierItem::setContextMenu(QMenu* menu)
 
 void StatusNotifierItem::Activate(int x, int y)
 {
-    if (mStatus == "NeedsAttention")
-        mStatus = "Active";
+    if (mStatus == QLatin1String("NeedsAttention"))
+        mStatus = QLatin1String("Active");
 
     Q_EMIT activateRequested(QPoint(x, y));
 }
 
 void StatusNotifierItem::SecondaryActivate(int x, int y)
 {
-    if (mStatus == "NeedsAttention")
-        mStatus = "Active";
+    if (mStatus == QLatin1String("NeedsAttention"))
+        mStatus = QLatin1String("Active");
 
     Q_EMIT secondaryActivateRequested(QPoint(x, y));
 }
@@ -270,7 +270,7 @@ void StatusNotifierItem::ContextMenu(int x, int y)
 void StatusNotifierItem::Scroll(int delta, const QString &orientation)
 {
     Qt::Orientation orient = Qt::Vertical;
-    if (orientation.toLower() == "horizontal")
+    if (orientation.toLower() == QLatin1String("horizontal"))
         orient = Qt::Horizontal;
 
     Q_EMIT scrollRequested(delta, orient);
@@ -279,9 +279,9 @@ void StatusNotifierItem::Scroll(int delta, const QString &orientation)
 void StatusNotifierItem::showMessage(const QString& title, const QString& msg,
                                      const QString& iconName, int secs)
 {
-    QDBusInterface interface("org.freedesktop.Notifications", "/org/freedesktop/Notifications",
-                             "org.freedesktop.Notifications", mSessionBus);
-    interface.call("Notify", mTitle, (uint) 0, iconName, title,
+    QDBusInterface interface(QLatin1String("org.freedesktop.Notifications"), QLatin1String("/org/freedesktop/Notifications"),
+                             QLatin1String("org.freedesktop.Notifications"), mSessionBus);
+    interface.call(QLatin1String("Notify"), mTitle, (uint) 0, iconName, title,
                    msg, QStringList(), QVariantMap(), secs);
 }
 


### PR DESCRIPTION
* Disables automatic conversions from 8-bit strings (char *) to unicode
  QStrings.
* Disables automatic conversion from QString to 8-bit strings (char *).
* Disables automatic conversions from QByteArray to const char * or const
  void *.
* Disables automatic conversions from QString (or char *) to QUrl.
* Use QStringBuilder for more efficient string creation.

It make us aware of string and encoding conversions.