### PR TITLE
Improves libmf-qt versioned .so handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,18 +16,30 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(LXQTBT_MINIMUM_VERSION "0.6.0")
 set(QT_MINIMUM_VERSION "5.7.1")
 set(QTXDG_MINIMUM_VERSION "3.3.0")
-set(FMQT_SO_VERSION "6")
-
-add_definitions(
-    -DFMQT_SO_VERSION=\"${FMQT_SO_VERSION}\"
-)
 
 find_package(Qt5DBus ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5LinguistTools ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5Widgets ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5XdgIconLoader ${QTXDG_MINIMUM_VERSION} REQUIRED)
 find_package(lxqt-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
+find_package(fm-qt)
 find_package(dbusmenu-qt5 REQUIRED)
+
+if (fm-qt_FOUND)
+    get_target_property(LIB_FM_QT_CONFIGURATIONS fm-qt IMPORTED_CONFIGURATIONS)
+    if (LIB_FM_QT_CONFIGURATIONS)
+        # Extract the .soname from the first configuration found.
+        # We don't use configuration mapping. Any config serves the purpose
+        list(GET LIB_FM_QT_CONFIGURATIONS 0 LIB_FM_QT_FIRST_CONFIGURATION)
+        get_target_property(LIB_FM_QT_SONAME fm-qt IMPORTED_SONAME_${LIB_FM_QT_FIRST_CONFIGURATION})
+    else()
+        message(WARNING "libfm-qt found, but no configuration found. Check your libfm-qt installation. Unversioned libfm-qt will be used.")
+        set(LIB_FM_QT_SONAME "libfm-qt")
+    endif()
+else()
+    set(LIB_FM_QT_SONAME "libfm-qt")
+endif()
+mark_as_advanced(LIB_FM_QT_SONAME)
 
 # Patch Version 0
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,7 @@ target_compile_definitions(qtlxqt
         "QT_NO_CAST_TO_ASCII"
         "QT_NO_URL_CAST_FROM_STRING"
         "QT_NO_CAST_FROM_BYTEARRAY"
+        "LIB_FM_QT_SONAME=\"${LIB_FM_QT_SONAME}\""
 )
 
 target_link_libraries(qtlxqt

--- a/src/lxqtplatformtheme.cpp
+++ b/src/lxqtplatformtheme.cpp
@@ -239,7 +239,7 @@ QPlatformDialogHelper *LXQtPlatformTheme::createPlatformDialogHelper(DialogType 
         // The createFileDialogHelper() method is dynamically loaded from libfm-qt on demand
         if(createFileDialogHelper == nullptr) {
             // try to dynamically load versioned libfm-qt.so
-            QLibrary libfmQtLibrary{QLatin1String("libfm-qt"), QLatin1String(FMQT_SO_VERSION)};
+            QLibrary libfmQtLibrary{QLatin1String(LIB_FM_QT_SONAME)};
             libfmQtLibrary.load();
             if(!libfmQtLibrary.isLoaded()) {
                 return nullptr;


### PR DESCRIPTION
We don't need to manually bump the libfm-qt ABI versions. We detect it at
build time.

An enhanced version b1abe51484ad253a768f57594570bc3e3f16e362.
Ref: lxqt/lxqt/issues/391