### PR TITLE
Remove (duplicated) string casts definitions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,11 +29,6 @@ add_library(qtlxqt MODULE ${qtlxqt_HDRS} ${qtlxqt_SRCS})
 target_compile_definitions(qtlxqt
     PRIVATE
         "QT_NO_FOREACH"
-        "QT_USE_QSTRINGBUILDER"
-        "QT_NO_CAST_FROM_ASCII"
-        "QT_NO_CAST_TO_ASCII"
-        "QT_NO_URL_CAST_FROM_STRING"
-        "QT_NO_CAST_FROM_BYTEARRAY"
         "LIB_FM_QT_SONAME=\"${LIB_FM_QT_SONAME}\""
 )
 


### PR DESCRIPTION
Already defined in LXQtCompilerSettings.