### PR TITLE
Made the palette configurable in `LXQtPlatformTheme`

### DIFF
--- a/src/lxqtplatformtheme.h
+++ b/src/lxqtplatformtheme.h
@@ -109,6 +109,8 @@ private:
     QFileSystemWatcher *settingsWatcher_;
     QString settingsFile_;
 
+    QPalette *LXQtPalette_;
+
     QStringList xdgIconThemePaths() const;
 };
 


### PR DESCRIPTION
Only the window (= button) color can be configured for now — `QPalette::QPalette(const QColor&)` calculates the other colors automatically — but, if needed, more customization could be added later, although, IMHO, it is better not to confuse users with too many colors.

The default color is that of Fusion's window.

If an option is added to `lxqt-config`, users could change not only Fusion's look-and-feel but also Breeze's, without needing KDE's systemsettings5.

Note 1: This was started to compensate for the ugly color Qt 5.15 gave to Fusion. IMO, that's a Qt issue but we don't need to worry about it.

Note 2: I'll make another PR for `lxqt-config` after the current one is decided.

Closes https://github.com/lxqt/lxqt-qtplugin/issues/54