### PR TITLE
Fixed mistakes in setting window color

### DIFF
--- a/src/lxqtplatformtheme.cpp
+++ b/src/lxqtplatformtheme.cpp
@@ -99,14 +99,6 @@ void LXQtPlatformTheme::loadSettings() {
     QSettings settings(QSettings::UserScope, QLatin1String("lxqt"), QLatin1String("lxqt"));
     settingsFile_ = settings.fileName();
 
-    // TODO: Qt 5.15 enforces Qt::gray. Later, we could have a completely configurable palette
-    // but, for now, only the window (button) color is set, with Fusion's window color as the fallback.
-    QColor winColor;
-    winColor.setNamedColor(settings.value(QLatin1String("window_color"), QLatin1String("#efefef")).toString());
-    if(!winColor.isValid())
-        winColor.setNamedColor(QStringLiteral("#efefef"));
-    LXQtPalette_ = new QPalette(winColor);
-
     // icon theme
     iconTheme_ = settings.value(QLatin1String("icon_theme"), QLatin1String("oxygen")).toString();
     iconFollowColorScheme_ = settings.value(QLatin1String("icon_follow_color_scheme"), iconFollowColorScheme_).toBool();
@@ -129,6 +121,20 @@ void LXQtPlatformTheme::loadSettings() {
 
     // widget style
     style_ = settings.value(QLatin1String("style"), QLatin1String("fusion")).toString();
+
+    // window color
+    // Later, we could have a completely configurable palette but, for now,
+    // only the window (button) color is set, with Fusion's window color as the fallback.
+    QColor oldWinColor = winColor_;
+    winColor_.setNamedColor(settings.value(QLatin1String("window_color"), QLatin1String("#efefef")).toString());
+    if(!winColor_.isValid())
+        winColor_.setNamedColor(QStringLiteral("#efefef"));
+    if(oldWinColor != winColor_)
+    {
+        if(LXQtPalette_)
+            delete LXQtPalette_;
+        LXQtPalette_ = new QPalette(winColor_);
+    }
 
     // SystemFont
     fontStr_ = settings.value(QLatin1String("font")).toString();
@@ -178,13 +184,14 @@ void LXQtPlatformTheme::onSettingsChanged() {
     // update the settings and repaint the UI. We need to do it ourselves
     // through dirty hacks and private Qt internal APIs.
     QString oldStyle = style_;
+    QColor oldWinColor = winColor_;
     QString oldIconTheme = iconTheme_;
     QString oldFont = fontStr_;
     QString oldFixedFont = fixedFontStr_;
 
     loadSettings(); // reload the config file
 
-    if(style_ != oldStyle) // the widget style is changed
+    if(style_ != oldStyle || oldWinColor != winColor_) // the widget style or window color is changed
     {
         // ask Qt5 to apply the new style
         if (qobject_cast<QApplication *>(QCoreApplication::instance()))

--- a/src/lxqtplatformtheme.cpp
+++ b/src/lxqtplatformtheme.cpp
@@ -123,8 +123,8 @@ void LXQtPlatformTheme::loadSettings() {
     style_ = settings.value(QLatin1String("style"), QLatin1String("fusion")).toString();
 
     // window color
-    // Later, we could have a completely configurable palette but, for now,
-    // only the window (button) color is set, with Fusion's window color as the fallback.
+    // NOTE: Later, we might add more colors but, for now, only the window
+    // (= button) color is set, with Fusion's window color as the fallback.
     QColor oldWinColor = winColor_;
     winColor_.setNamedColor(settings.value(QLatin1String("window_color"), QLatin1String("#efefef")).toString());
     if(!winColor_.isValid())
@@ -191,11 +191,15 @@ void LXQtPlatformTheme::onSettingsChanged() {
 
     loadSettings(); // reload the config file
 
-    if(style_ != oldStyle || oldWinColor != winColor_) // the widget style or window color is changed
+    if(style_ != oldStyle || winColor_ != oldWinColor) // the widget style or window color is changed
     {
         // ask Qt5 to apply the new style
-        if (qobject_cast<QApplication *>(QCoreApplication::instance()))
+        if(qobject_cast<QApplication *>(QCoreApplication::instance()))
+        {
             QApplication::setStyle(style_);
+            if(LXQtPalette_)
+                QApplication::setPalette(*LXQtPalette_); // Qt 5.15 needs this and it's safe otherwise
+        }
     }
 
     if(iconTheme_ != oldIconTheme) { // the icon theme is changed
@@ -230,6 +234,10 @@ void LXQtPlatformTheme::onSettingsChanged() {
         // Qt5 added a QEvent::ThemeChange event.
         QEvent event(QEvent::ThemeChange);
         QApplication::sendEvent(widget, &event);
+        // Also, set the palette because it may not be updated for some widgets.
+        // WARNING: The app palette should be used, not LXQtPalette_, because
+        // some widget styles have their own palettes.
+        widget->setPalette(QApplication::palette());
     }
 }
 

--- a/src/lxqtplatformtheme.h
+++ b/src/lxqtplatformtheme.h
@@ -97,6 +97,7 @@ private:
     // other Qt settings
     // widget
     QString style_;
+    QColor winColor_;
     QString fontStr_;
     QFont font_;
     QString fixedFontStr_;


### PR DESCRIPTION
Three mistakes are corrected in the previous commit (https://github.com/lxqt/lxqt-qtplugin/commit/8a5a1999762c4c020e1cf3939d6eb6acf84b9a71), the first one being a serious bug. The fixes are as follows:

 1. `LXQtPlatformTheme::loadSettings()` may be called multiple times due to changes in `~/.config/lxqt/lxqt.conf`. Therefore, `LXQtPalette_` should be deleted before being created again; otherwise, a memory leak will exist.

 2. The new key `window_color` should belong to the "Qt" group because it is about a Qt setting.

 3. If the value of `window_color` is changed, the application should be restyled; otherwise, the color change won't have effect immediately and the application should be restarted to reflect it.