### PR TITLE
Do not reset widget palettes on changing style

### DIFF
--- a/src/lxqtplatformtheme.cpp
+++ b/src/lxqtplatformtheme.cpp
@@ -234,10 +234,6 @@ void LXQtPlatformTheme::onSettingsChanged() {
         // Qt5 added a QEvent::ThemeChange event.
         QEvent event(QEvent::ThemeChange);
         QApplication::sendEvent(widget, &event);
-        // Also, set the palette because it may not be updated for some widgets.
-        // WARNING: The app palette should be used, not LXQtPalette_, because
-        // some widget styles have their own palettes.
-        widget->setPalette(QApplication::palette());
     }
 }
 


### PR DESCRIPTION
Generally, resetting a widget's palette from outside its code is a bad practice because the palette may have been changed for a reason.

If the custom palette of a widget needs an update when the style changes, the program itself is responsible for that; otherwise, the program has a bug — as in libfm-qt's places view (which I'll fix soon) and Dolphin's main view (which will never be fixed).