### PR TITLE
Enforce Fusion's highlight color when setting window color

### DIFF
--- a/src/lxqtplatformtheme.cpp
+++ b/src/lxqtplatformtheme.cpp
@@ -134,6 +134,9 @@ void LXQtPlatformTheme::loadSettings() {
         if(LXQtPalette_)
             delete LXQtPalette_;
         LXQtPalette_ = new QPalette(winColor_);
+        // Qt's default highlight color and that of Fusion may be different. This is a workaround:
+        LXQtPalette_->setColor(QPalette::Highlight, QColor(60, 140, 230));
+        LXQtPalette_->setColor(QPalette::HighlightedText, QColor(255, 255, 255));
     }
 
     // SystemFont


### PR DESCRIPTION
Because Qt's default highlight color is `#000080` while that of Fusion is `#3c8ce6`. Not only the latter is more elegant but also the patch fixes the color change after restarting apps.

Also, the highlighted text color is set to white for the sake of certainty.