### PR TITLE
Support more palette colors for better customization

### DIFF
--- a/src/lxqtplatformtheme.h
+++ b/src/lxqtplatformtheme.h
@@ -97,7 +97,10 @@ private:
     // other Qt settings
     // widget
     QString style_;
-    QColor winColor_;
+    QColor winColor_, baseColor_, highlightColor_,
+           winTextColor_, textColor_, highlightedTextColor_,
+           linkColor_, linkVisitedColor_;
+    bool paletteChanged_;
     QString fontStr_;
     QFont font_;
     QString fixedFontStr_;


### PR DESCRIPTION
Eight palette colors are supported.

Also:

 1. Colors are moved to a separate section named "Palette".
 2. The app is polished after its palette is set. Previously, the lack of polishing interfered with styles that had internal palettes (like Kvantum and gtk2), so that an app restart was needed for them to show their own colors.

An `lxqt-config` PR will follow this to use it.