### PR TITLE
Workaround for Qt's poor handling of some dark palettes

### DIFF
--- a/src/lxqtplatformtheme.cpp
+++ b/src/lxqtplatformtheme.cpp
@@ -169,8 +169,17 @@ void LXQtPlatformTheme::loadSettings() {
         if (baseColor_.isValid())
         {
             LXQtPalette_->setColor(QPalette::Base, baseColor_);
-            // See Qt -> qpalette.cpp -> qt_fusionPalette()
-            LXQtPalette_->setColor(QPalette::Disabled, QPalette::Base, winColor_);
+            // Qt makes the alternate base color (used by some item views) by mixing the button
+            // color (= window color) and base color. That can result in unreadable texts when
+            // the base and window colors have a high contrast with each other.
+            color = baseColor_;
+            int l = color.lightness();
+            if (l < 127)
+                l += 10;
+            else
+                l -= 10;
+            color.setHsl(color.hue(), color.saturation(), l);
+            LXQtPalette_->setColor(QPalette::AlternateBase, color);
         }
         if (highlightColor_.isValid())
         {


### PR DESCRIPTION
Qt implicitly assumes that the base and window colors don't have a high contrast with each other and uses the latter to get some colors related to the former, resulting in unreadable texts:

 1. Qt sets the disabled base color to the window color. The current patch leaves the disabled base color to be equal to the enabled one (disabled widgets are distinguished from enabled ones in other ways) because the window color may have a high contrast with it and make disabled texts unreadable.
 2. Qt gets the alternate base color (used by some item views) by mixing the base and window colors. The patch gets it by decreasing/increasing the lightness of the base color a little.

Closes https://github.com/lxqt/lxqt-qtplugin/issues/69

NOTE: If window and base colors have a high contrast with each other, symbolic SVG icons might be white/black on white/black backgrounds. Nothing can be done by us for avoiding that — KDE devs made the same mistake that was hidden inside Qt — but, IMO, we shouldn't disallow this kind of palette (→ UNIX philosophy).