### PR TITLE
Added an option to show context menus on releasing mouse button

### DIFF
--- a/src/lxqtplatformtheme.cpp
+++ b/src/lxqtplatformtheme.cpp
@@ -114,6 +114,9 @@ void LXQtPlatformTheme::loadSettings() {
     // single click activation
     singleClickActivate_ = settings.value(QLatin1String("single_click_activate")).toBool();
 
+    // showing context menus on releasing right mouse button
+    contextMenuOnMouseRelease_ = settings.value(QLatin1String("context_menu_on_mouse_release")).toBool();
+
     // palette
     settings.beginGroup(QLatin1String("Palette"));
     paletteChanged_ = false;
@@ -460,7 +463,7 @@ QVariant LXQtPlatformTheme::themeHint(ThemeHint hint) const {
     case DialogSnapToDefaultButton:
         break;
     case ContextMenuOnMouseRelease:
-        break;
+        return QVariant(contextMenuOnMouseRelease_);
     case MousePressAndHoldInterval:
         break;
     case MouseDoubleClickDistance:

--- a/src/lxqtplatformtheme.h
+++ b/src/lxqtplatformtheme.h
@@ -91,6 +91,7 @@ private:
     // LXQt settings
     QString iconTheme_;
     Qt::ToolButtonStyle toolButtonStyle_;
+    bool contextMenuOnMouseRelease_;
     bool singleClickActivate_;
     bool iconFollowColorScheme_;
 


### PR DESCRIPTION
It brings the behavior of MS Windows to Qt apps. The key is `context_menu_on_mouse_release` under the `[General]` section of `~/.config/lxqt/lxqt.conf`, and it can be `true` or `false` (`false` by default).

Pros:

 1. With this option enabled, the user can right click without fearing that a menu-item might be activated by mistake. Many users have experienced unintentional activation.
 2. It makes right click be a real click (= press + release) and consistent with left click.
 3. LXQt might be the first Linux DE providing its users with this option. That could motivate others to take it seriously. In particular, Qt might become more self-consistent about it.

Cons:

 1. Running apps can't see its toggling. App restart — or preferably, session restart — is needed.
 2. There's a hidden problem in `libqtxdg` (inherited from a similar problem in Qt) and another one in lxqt-panel's main menu. But they can be fixed easily.
 3. Of course, nothing can be done about non-Qt apps.

NOTE: It can't be confusing to users because context menus are already shown on mouse release in notification area (an inconsistency not noticed by many).