### PR TITLE
Set mouse cursor theme and size

### DIFF
--- a/src/lxqtplatformtheme.cpp
+++ b/src/lxqtplatformtheme.cpp
@@ -255,6 +255,14 @@ void LXQtPlatformTheme::loadSettings() {
     // keyboard
     cursorFlashTime_ = settings.value(QLatin1String("cursorFlashTime"));
     settings.endGroup();
+
+    // mouse cursor
+    QSettings sessionSettings(QSettings::UserScope, QLatin1String("lxqt"), QLatin1String("session"));
+    sessionSettings.beginGroup(QStringLiteral("Mouse"));
+    mouseCursorTheme_ = sessionSettings.value(QLatin1String("cursor_theme"));
+    int curSize = sessionSettings.value(QLatin1String("cursor_size"), 16).toInt();
+    mouseCursorSize_ = QSize(curSize, curSize);
+    sessionSettings.endGroup();
 }
 
 // this is called whenever the config file is changed.
@@ -475,6 +483,10 @@ QVariant LXQtPlatformTheme::themeHint(ThemeHint hint) const {
         return wheelScrollLines_;
     case QPlatformTheme::ShowShortcutsInContextMenus:
         return QVariant(true);
+    case MouseCursorTheme:
+        return mouseCursorTheme_;
+    case MouseCursorSize:
+        return QVariant(mouseCursorSize_);
     default:
         break;
     }

--- a/src/lxqtplatformtheme.h
+++ b/src/lxqtplatformtheme.h
@@ -109,8 +109,12 @@ private:
     // mouse
     QVariant doubleClickInterval_;
     QVariant wheelScrollLines_;
+    // mouse cursor
+    QVariant mouseCursorTheme_;
+    QSize mouseCursorSize_;
     // keyboard
     QVariant cursorFlashTime_;
+
     QFileSystemWatcher *settingsWatcher_;
     QString settingsFile_;
 


### PR DESCRIPTION
`MouseCursorTheme` and `MouseCursorSize` were introduced into Qt 6.5.

Closes https://github.com/lxqt/lxqt-qtplugin/issues/78