### PR TITLE
Set toolbar icon size

### DIFF
--- a/src/lxqtplatformtheme.cpp
+++ b/src/lxqtplatformtheme.cpp
@@ -113,6 +113,11 @@ void LXQtPlatformTheme::loadSettings() {
     else
         toolButtonStyle_ = static_cast<Qt::ToolButtonStyle>(value);
 
+    // toolbar icon size
+    toolBarIconSize_ = qBound(0, settings.value(QLatin1String("tool_bar_icon_size")).toInt(), 48);
+    if (toolBarIconSize_ < 16)
+        toolBarIconSize_ = 0; // let the style decide
+
     // single click activation
     singleClickActivate_ = settings.value(QLatin1String("single_click_activate")).toBool();
 
@@ -458,7 +463,7 @@ QVariant LXQtPlatformTheme::themeHint(ThemeHint hint) const {
     case ToolButtonStyle:
         return QVariant(toolButtonStyle_);
     case ToolBarIconSize:
-        break;
+        return QVariant(toolBarIconSize_);
     case ItemViewActivateItemOnSingleClick:
         return QVariant(singleClickActivate_);
     case SystemIconThemeName:

--- a/src/lxqtplatformtheme.h
+++ b/src/lxqtplatformtheme.h
@@ -92,6 +92,7 @@ private:
     // LXQt settings
     QString iconTheme_;
     Qt::ToolButtonStyle toolButtonStyle_;
+    int toolBarIconSize_;
     bool singleClickActivate_;
     bool iconFollowColorScheme_;
 


### PR DESCRIPTION
The default is 0, which means that the Qt style sets it. Any value less than 16 is seen as 0, and values greater than 48 are seen as 48.

Closes https://github.com/lxqt/lxqt-qtplugin/issues/90