### PR TITLE
cmake: fix build with Qt 6.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,11 @@ find_package(Qt6DBus ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt6LinguistTools ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt6Widgets ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt6XdgIconLoader ${QTXDG_MINIMUM_VERSION} REQUIRED)
+
+if (Qt6Gui_VERSION VERSION_GREATER_EQUAL "6.10.0")
+    find_package(Qt6GuiPrivate REQUIRED)
+endif()
+
 find_package(lxqt2-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 find_package(dbusmenu-lxqt ${DBUSMENU_MINIMUM_VERSION} REQUIRED)
 find_package(fm-qt6 ${FMQT_MINIMUM_VERSION} REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,10 +33,13 @@ target_compile_definitions(qtlxqt
 )
 
 target_link_libraries(qtlxqt
-    Qt6::Widgets
-    Qt6::DBus
-    dbusmenu-lxqt
-    Qt6XdgIconLoader
+    PRIVATE
+        Qt6::GuiPrivate
+    PUBLIC
+        Qt6::Widgets
+        Qt6::DBus
+        dbusmenu-lxqt
+        Qt6XdgIconLoader
 )
 
 lxqt_query_qt(_QT_PLUGINS_DIR QT_INSTALL_PLUGINS)


### PR DESCRIPTION
The 'Qt6FooPrivate' targets have been split into separate CMake files
in Qt 6.9, and require a 'find_package(Qt6FooPrivate)' call starting
with Qt 6.10.

See also: https://bugreports.qt.io/browse/QTBUG-87776
